### PR TITLE
Support .NET 3.5 by removing the use to Lazy<T> and IReadOnlyList<T>

### DIFF
--- a/OggVorbisEncoder/Block.cs
+++ b/OggVorbisEncoder/Block.cs
@@ -2076,7 +2076,7 @@ namespace OggVorbisEncoder
             1.0000000000F, 1.0000000000F, 1.0000000000F, 1.0000000000F
         };
 
-        public static readonly IReadOnlyList<IReadOnlyList<float>> Windows = new[]
+        public static readonly float[][] Windows = new[]
         {
             Win64,
             Win128,

--- a/OggVorbisEncoder/Comments.cs
+++ b/OggVorbisEncoder/Comments.cs
@@ -7,7 +7,7 @@ namespace OggVorbisEncoder
     {
         private readonly List<string> _userComments = new List<string>();
 
-        public IReadOnlyList<string> UserComments => _userComments;
+        public List<string> UserComments => _userComments;
 
         public void AddTag(string tag, string contents)
         {

--- a/OggVorbisEncoder/EncodeSetup.cs
+++ b/OggVorbisEncoder/EncodeSetup.cs
@@ -7,8 +7,7 @@ namespace OggVorbisEncoder
 {
     public class EncodeSetup
     {
-        private static readonly Lazy<IEnumerable<ISetupTemplate>> SetupTemplates =
-            new Lazy<IEnumerable<ISetupTemplate>>(CreateTemplates);
+        private static readonly IEnumerable<ISetupTemplate> SetupTemplates = CreateTemplates();
 
         public EncodeSetup(ISetupTemplate template, double baseSetting)
         {
@@ -55,7 +54,7 @@ namespace OggVorbisEncoder
             int sampleRate,
             float quality)
         {
-            foreach (var template in SetupTemplates.Value)
+            foreach (var template in SetupTemplates)
             {
                 if ((template.CouplingRestriction != -1)
                     && (template.CouplingRestriction != channels))

--- a/OggVorbisEncoder/LookupCollection.cs
+++ b/OggVorbisEncoder/LookupCollection.cs
@@ -8,12 +8,12 @@ namespace OggVorbisEncoder
     {
         private LookupCollection(
             EnvelopeLookup envelopeLookup,
-            IReadOnlyList<MdctLookup> transformLookup,
+            MdctLookup[] transformLookup,
             PsyGlobalLookup psyGlobalLookup,
-            IReadOnlyList<PsyLookup> psyLookup,
-            IReadOnlyList<DrftLookup> fftLookup,
-            IReadOnlyList<FloorLookup> floorLookup,
-            IReadOnlyList<ResidueLookup> residueLookup)
+            PsyLookup[] psyLookup,
+            DrftLookup[] fftLookup,
+            FloorLookup[] floorLookup,
+            ResidueLookup[] residueLookup)
         {
             EnvelopeLookup = envelopeLookup;
             TransformLookup = transformLookup;
@@ -25,12 +25,12 @@ namespace OggVorbisEncoder
         }
 
         public EnvelopeLookup EnvelopeLookup { get; }
-        public IReadOnlyList<MdctLookup> TransformLookup { get; }
+        public MdctLookup[] TransformLookup { get; }
         public PsyGlobalLookup PsyGlobalLookup { get; }
-        public IReadOnlyList<PsyLookup> PsyLookup { get; }
-        public IReadOnlyList<DrftLookup> FftLookup { get; }
-        public IReadOnlyList<FloorLookup> FloorLookup { get; }
-        public IReadOnlyList<ResidueLookup> ResidueLookup { get; }
+        public PsyLookup[] PsyLookup { get; }
+        public DrftLookup[] FftLookup { get; }
+        public FloorLookup[] FloorLookup { get; }
+        public ResidueLookup[] ResidueLookup { get; }
 
         public static LookupCollection Create(VorbisInfo info)
         {

--- a/OggVorbisEncoder/Lookups/EnvelopeLookup.cs
+++ b/OggVorbisEncoder/Lookups/EnvelopeLookup.cs
@@ -14,7 +14,7 @@ namespace OggVorbisEncoder.Lookups
         private const int EnvelopeMinStretch = 2;
         private const int EnvelopeMaxStretch = 12; // One third full block
         private readonly EnvelopeBand[] _bands;
-        private readonly IReadOnlyList<EnvelopeFilterState> _filters;
+        private readonly EnvelopeFilterState[] _filters;
         private readonly MdctLookup _mdctLookup;
 
         private readonly float[] _mdctWindow;
@@ -165,7 +165,7 @@ namespace OggVorbisEncoder.Lookups
         }
 
         private int AmpPcm(
-            IReadOnlyList<float> pcm,
+            float[] pcm,
             int pcmOffset,
             int filterOffset)
         {

--- a/OggVorbisEncoder/Lookups/FloorLookup.cs
+++ b/OggVorbisEncoder/Lookups/FloorLookup.cs
@@ -416,7 +416,7 @@ namespace OggVorbisEncoder.Lookups
             return y0 + off;
         }
 
-        private static int PostY(IReadOnlyList<int> a, IReadOnlyList<int> b, int pos)
+        private static int PostY(int[] a, int[] b, int pos)
         {
             if (a[pos] < 0)
                 return b[pos];

--- a/OggVorbisEncoder/Lookups/PsyLookup.cs
+++ b/OggVorbisEncoder/Lookups/PsyLookup.cs
@@ -386,8 +386,8 @@ namespace OggVorbisEncoder.Lookups
         }
 
         public void OffsetAndMix(
-            IReadOnlyList<float> noise,
-            IReadOnlyList<float> tone,
+            float[] noise,
+            float[] tone,
             int offsetIndex,
             IList<float> logmask,
             IList<float> mdct,
@@ -645,8 +645,8 @@ namespace OggVorbisEncoder.Lookups
             int blobno,
             PsyGlobal psyGlobal,
             Mapping mapping,
-            IReadOnlyList<float[]> mdct,
-            IReadOnlyList<int[]> iwork,
+            float[][] mdct,
+            int[][] iwork,
             bool[] nonzero,
             int slidingLowpass,
             int channels)
@@ -1101,14 +1101,14 @@ namespace OggVorbisEncoder.Lookups
             }
         }
 
-        private static void MinCurve(IList<float> c1, IReadOnlyList<float> c2)
+        private static void MinCurve(IList<float> c1, float[] c2)
         {
             for (var i = 0; i < EhmerMax; i++)
                 if (c2[i] < c1[i])
                     c1[i] = c2[i];
         }
 
-        private static void MaxCurve(IList<float> c1, IReadOnlyList<float> c2)
+        private static void MaxCurve(IList<float> c1, float[] c2)
         {
             for (var i = 0; i < EhmerMax; i++)
                 if (c2[i] > c1[i])
@@ -1140,13 +1140,13 @@ namespace OggVorbisEncoder.Lookups
 
         #region SOURCE DATA
 
-        private static readonly IReadOnlyList<float> StereoThresholdsLimit = new[]
+        private static readonly float[] StereoThresholdsLimit = new[]
             {0, .5f, 1, 1.5f, 2, 2.5f, 4.5f, 8.5f, 9e10f};
 
-        private static readonly IReadOnlyList<float> StereoThresholds = new[]
+        private static readonly float[] StereoThresholds = new[]
             {0, .5f, 1, 1.5f, 2.5f, 4.5f, 8.5f, 16.5f, 9e10f};
 
-        private static readonly IReadOnlyList<float> DecibelLookup = new[]
+        private static readonly float[] DecibelLookup = new[]
         {
             1.0649863e-07f, 1.1341951e-07f, 1.2079015e-07f, 1.2863978e-07f,
             1.3699951e-07f, 1.4590251e-07f, 1.5538408e-07f, 1.6548181e-07f,

--- a/OggVorbisEncoder/Lookups/ResidueLookup.cs
+++ b/OggVorbisEncoder/Lookups/ResidueLookup.cs
@@ -11,7 +11,7 @@ namespace OggVorbisEncoder.Lookups
         private readonly Residue _residue;
         private readonly int _stages;
 
-        public ResidueLookup(Residue residue, IReadOnlyList<CodeBook> fullBooks)
+        public ResidueLookup(Residue residue, CodeBook[] fullBooks)
         {
             if (residue.ResidueType != ResidueType.Two)
                 throw new NotImplementedException("ResidueTypes other than 'Two' are not yet implemented");
@@ -217,7 +217,7 @@ namespace OggVorbisEncoder.Lookups
             return null;
         }
 
-        private int[][] ResTwoClass(IReadOnlyList<int[]> couples, int channels)
+        private int[][] ResTwoClass(int[][] couples, int channels)
         {
             var n = _residue.End - _residue.Begin;
 

--- a/OggVorbisEncoder/OggStream.cs
+++ b/OggVorbisEncoder/OggStream.cs
@@ -12,7 +12,7 @@ namespace OggVorbisEncoder
 
         #region CHECKSUM
 
-        private static readonly IReadOnlyList<uint> Checksum = new uint[]
+        private static readonly uint[] Checksum = new uint[]
         {
             0x00000000, 0x04c11db7, 0x09823b6e, 0x0d4326d9,
             0x130476dc, 0x17c56b6b, 0x1a864db2, 0x1e475005,

--- a/OggVorbisEncoder/OggVorbisEncoder.csproj
+++ b/OggVorbisEncoder/OggVorbisEncoder.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard1.0;net35</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/OggVorbisEncoder/ProcessingState.cs
+++ b/OggVorbisEncoder/ProcessingState.cs
@@ -23,7 +23,7 @@ namespace OggVorbisEncoder
         private readonly float[][] _pcm;
 
         private readonly VorbisInfo _vorbisInfo;
-        private readonly IReadOnlyList<int> _window;
+        private readonly int[] _window;
 
         private int _centerWindow;
         private int _currentWindow;
@@ -39,7 +39,7 @@ namespace OggVorbisEncoder
             VorbisInfo vorbisInfo,
             LookupCollection lookups,
             float[][] pcm,
-            IReadOnlyList<int> window,
+            int[] window,
             int centerWindow)
         {
             _vorbisInfo = vorbisInfo;
@@ -114,7 +114,7 @@ namespace OggVorbisEncoder
         }
 
         private static void UpdatePcmFromLpcPredict(
-            IReadOnlyList<float> lpcCoeff,
+            float[] lpcCoeff,
             IList<float> data,
             int offset,
             int m,
@@ -468,10 +468,10 @@ namespace OggVorbisEncoder
             int pcmEnd,
             EncodeBuffer buffer,
             Mapping mapping,
-            IReadOnlyList<int[]> work,
-            IReadOnlyList<int[][]> floorPosts,
+            int[][] work,
+            int[][][] floorPosts,
             PsyLookup psyLookup,
-            IReadOnlyList<float[]> gmdct)
+            float[][] gmdct)
         {
             var codecSetup = _vorbisInfo.CodecSetup;
             var channels = pcm.Length;
@@ -668,9 +668,9 @@ namespace OggVorbisEncoder
             int pcmEnd,
             Mapping mapping,
             IList<int[][]> floorPosts,
-            IReadOnlyList<float[]> gmdct,
+            float[][] gmdct,
             PsyLookup psyLookup,
-            IReadOnlyList<float> localAmpMax)
+            float[] localAmpMax)
         {
             var noise = new float[pcmEnd/2];
             var tone = new float[pcmEnd/2];

--- a/OggVorbisEncoder/VorbisInfo.cs
+++ b/OggVorbisEncoder/VorbisInfo.cs
@@ -261,9 +261,9 @@ namespace OggVorbisEncoder
         private static void PsyParamSetup(
             CodecSetup codecSetup,
             int encodeSetupBaseSetting,
-            IReadOnlyList<int> noiseNormalStart,
-            IReadOnlyList<int> noiseNormalPartition,
-            IReadOnlyList<double> noiseNormalThreshold)
+            int[] noiseNormalStart,
+            int[] noiseNormalPartition,
+            double[] noiseNormalThreshold)
         {
             var block = codecSetup.PsyParams.Count;
 
@@ -280,9 +280,9 @@ namespace OggVorbisEncoder
         private static void FloorSetup(
             CodecSetup codecSetup,
             int encodeSetupBaseSetting,
-            IReadOnlyList<IStaticCodeBook[]> templateFloorBooks,
-            IReadOnlyList<Floor> templateFloorParams,
-            IReadOnlyList<int> templateFloorMappings)
+            IStaticCodeBook[][] templateFloorBooks,
+            Floor[] templateFloorParams,
+            int[] templateFloorMappings)
         {
             var sourceIndex = templateFloorMappings[encodeSetupBaseSetting];
             var clonedFloor = templateFloorParams[sourceIndex].Clone();
@@ -324,7 +324,7 @@ namespace OggVorbisEncoder
             CodecSetup codecSetup,
             int sampleRate,
             int channels,
-            IReadOnlyList<IMappingTemplate> templateMaps)
+            IMappingTemplate[] templateMaps)
         {
             var encodeSetupBaseSetting = (int) codecSetup.EncodeSetup.BaseSetting;
             var map = templateMaps[encodeSetupBaseSetting].Mapping;
@@ -484,8 +484,8 @@ namespace OggVorbisEncoder
         private static void GlobalPsychSetup(
             CodecSetup codecSetup,
             double encodeSetupTriggerSetting,
-            IReadOnlyList<PsyGlobal> templateGlobalParams,
-            IReadOnlyList<double> templateGlobalMapping)
+            PsyGlobal[] templateGlobalParams,
+            double[] templateGlobalMapping)
         {
             var setting = (int) encodeSetupTriggerSetting;
             var ds = encodeSetupTriggerSetting - setting;
@@ -523,7 +523,7 @@ namespace OggVorbisEncoder
         private static void GlobalStereo(
             CodecSetup codecSetup,
             int sampleRate,
-            IReadOnlyList<AdjStereo> templateStereoModes)
+            AdjStereo[] templateStereoModes)
         {
             var setting = (int) codecSetup.EncodeSetup.BaseSetting;
             var ds = codecSetup.EncodeSetup.BaseSetting - setting;
@@ -569,8 +569,8 @@ namespace OggVorbisEncoder
         private static void BlockSizeSetup(
             CodecSetup codecSetup,
             int index,
-            IReadOnlyList<int> templateBlockSizeShort,
-            IReadOnlyList<int> templateBlockSizeLong)
+            int[] templateBlockSizeShort,
+            int[] templateBlockSizeLong)
         {
             var blockshort = templateBlockSizeShort[index];
             var blocklong = templateBlockSizeLong[index];
@@ -582,9 +582,9 @@ namespace OggVorbisEncoder
             CodecSetup codecSetup,
             double toneMaskSetting,
             int block,
-            IReadOnlyList<Att3> templatePsyToneMasterAtt,
-            IReadOnlyList<int> templatePsyTone0Decibel,
-            IReadOnlyList<AdjBlock> templatePsyToneAdjLong)
+            Att3[] templatePsyToneMasterAtt,
+            int[] templatePsyTone0Decibel,
+            AdjBlock[] templatePsyToneAdjLong)
         {
             var setting = (int) toneMaskSetting;
             var ds = toneMaskSetting - setting;
@@ -619,8 +619,8 @@ namespace OggVorbisEncoder
             CodecSetup codecSetup,
             double noiseCompandSetting,
             int block,
-            IReadOnlyList<CompandBlock> templatePsyNoiseCompand,
-            IReadOnlyList<double> templatePsyNoiseCompandShortMapping)
+            CompandBlock[] templatePsyNoiseCompand,
+            double[] templatePsyNoiseCompandShortMapping)
         {
             var setting = (int) noiseCompandSetting;
             var ds = noiseCompandSetting - setting;
@@ -647,7 +647,7 @@ namespace OggVorbisEncoder
             CodecSetup codecSetup,
             double tonePeakLimitSetting,
             int block,
-            IReadOnlyList<int> templatePsyToneDecibelSuppress)
+            int[] templatePsyToneDecibelSuppress)
         {
             var setting = (int) tonePeakLimitSetting;
             var ds = tonePeakLimitSetting - setting;
@@ -661,9 +661,9 @@ namespace OggVorbisEncoder
             CodecSetup codecSetup,
             double noiseBiasSetting,
             int block,
-            IReadOnlyList<int> templatePsyNoiseDecibelSuppress,
-            IReadOnlyList<Noise3> templatePsyNoiseBiasLong,
-            IReadOnlyList<NoiseGuard> templatePsyNoiseGuards)
+            int[] templatePsyNoiseDecibelSuppress,
+            Noise3[] templatePsyNoiseBiasLong,
+            NoiseGuard[] templatePsyNoiseGuards)
         {
             var setting = (int) noiseBiasSetting;
             var ds = noiseBiasSetting - setting;


### PR DESCRIPTION
I wanted to use the library in Unity - but Unity only supports library that target .NET 3.5 or below.
I made some minimal changes to the library to make it also support .NET 3.5

I also changed the target .NET standard 2.0 to target .NET standard 1.0 - by targeting lower .NET standard version, you allow more applications that run lower version .NET framework to use your library, since it works in 1.0, you might as well target 1.0.