### PR TITLE
Fix exceptions when encoding in some cases due to Math.Abs

### DIFF
--- a/OggVorbisEncoder/Lookups/PsyLookup.cs
+++ b/OggVorbisEncoder/Lookups/PsyLookup.cs
@@ -186,7 +186,7 @@ public class PsyLookup
             for (var j = 0; j < Levels; j++)
                 for (var k = 0; k < EhmerMax; k++)
                 {
-                    var adj = centerBoost + Math.Abs(EhmerOffset - k) * centerDecayRate;
+                    var adj = centerBoost + MathExtensions.SafeAbs(EhmerOffset - k) * centerDecayRate;
 
                     if ((adj < 0) && (centerBoost > 0))
                         adj = 0;

--- a/OggVorbisEncoder/Lookups/ResidueLookup.cs
+++ b/OggVorbisEncoder/Lookups/ResidueLookup.cs
@@ -264,8 +264,8 @@ public class ResidueLookup
                 int k;
                 for (k = 0; k < _residue.Grouping; k++)
                 {
-                    if (Math.Abs(couples[j][offset + k]) > max) max = Math.Abs(couples[j][offset + k]);
-                    ent += Math.Abs(couples[j][offset + k]);
+                    if (MathExtensions.SafeAbs(couples[j][offset + k]) > max) max = MathExtensions.SafeAbs(couples[j][offset + k]);
+                    ent += MathExtensions.SafeAbs(couples[j][offset + k]);
                 }
                 ent = (int)(ent * (100.0f / _residue.Grouping));
 
@@ -296,13 +296,13 @@ public class ResidueLookup
             var angMax = 0;
             for (var g = 0; g < _residue.Grouping; g += channels)
             {
-                var abs = Math.Abs(couples[0][l]);
+                var abs = MathExtensions.SafeAbs(couples[0][l]);
                 if (abs > magMax)
                     magMax = abs;
 
                 for (var k = 1; k < channels; k++)
                 {
-                    abs = Math.Abs(couples[k][l]);
+                    abs = MathExtensions.SafeAbs(couples[k][l]);
                     if (abs > angMax)
                         angMax = abs;
                 }

--- a/OggVorbisEncoder/MathExtensions.cs
+++ b/OggVorbisEncoder/MathExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace OggVorbisEncoder;
+public static class MathExtensions
+{
+    public static int SafeAbs(int value)
+    {
+        // The absolute value of MinValue of int cannot be represented as int
+        // So we return a value that's one less than that. This is technically 
+        // "incorrect" value, because it's off by one, but for the purposes of representing
+        // amplitudes and other values it shouldn't matter
+        if (value == int.MinValue)
+            return int.MaxValue;
+
+        return Math.Abs(value);
+    }
+}


### PR DESCRIPTION
I've ran into an issue where sometimes during encoding, the process would throw an exception from Math.Abs, because the input value equals to int.MinValue, whose positive value cannot be represented as an int.

This changes the code, so it simply returns int.MaxValue in that case, which fixes those exceptions.